### PR TITLE
[ci skip] adding user @soeptas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @jonasvdd @jvdd
+* @soeptas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,5 +48,6 @@ about:
 
 extra:
   recipe-maintainers:
+    - soeptas
     - jvdd
     - jonasvdd


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @soeptas as instructed in #7.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #7